### PR TITLE
新增：帮助页面

### DIFF
--- a/demo.txt
+++ b/demo.txt
@@ -1,0 +1,5 @@
+Line 1
+Line 2
+Line 3
+This is a test file for RSNano
+Testing help page fix

--- a/simple_test.txt
+++ b/simple_test.txt
@@ -1,0 +1,1 @@
+Simple test

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -5,7 +5,7 @@ mod ui;
 
 use crate::args::Args;
 use crate::buffer::TextBuffer;
-use crate::direction::Direction;
+// use crate::direction::Direction; // 未使用，可去掉
 use crate::version::AppInfo;
 use crate::Result;
 
@@ -53,55 +53,16 @@ impl Editor {
         result
     }
 
-    fn main_loop(&mut self) -> Result<()> {
-        loop {
-            self.refresh_screen()?;
-            if self.should_quit {
-                break;
-            }
-            if crossterm::event::poll(std::time::Duration::from_millis(50))? {
-                if let crossterm::event::Event::Key(key_event) = crossterm::event::read()? {
-                    if key_event.kind == crossterm::event::KeyEventKind::Press {
-                        input::process_key(self, key_event)?;
-                    },
-                }
-            }
-            let new_size = crossterm::terminal::size()?;
-            if new_size != self.terminal_size {
-                self.terminal_size = new_size;
-                // 如果正在显示帮助页且终端大小改变，需要重新绘制
-                if self.show_help_page {
-                    self.help_page_drawn = false;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    // 帮助
-    if self.show_help_page {
-        self.draw_help_page()?;
-        return Ok(());
-    }
-
-    // 显示帮助页面
-    // 如果正在显示帮助页面，任意按键关闭帮助页面
-    if self.show_help_page {
-        match key_event.code {
-            KeyCode::Esc | KeyCode::Char(_) | KeyCode::Enter | KeyCode::Backspace => {
-                self.show_help_page = false;
-                self.status_message.clear();
-            }
-            _ => {}
-        }
-        return Ok(());
-    }
-
     fn refresh_screen(&mut self) -> Result<()> {
         ui::refresh_screen(self)
     }
 
     fn draw_help_page(&self) -> Result<()> {
+        use crossterm::{
+            cursor, execute, style,
+            terminal::{self, ClearType},
+        };
+        use std::io::stdout;
         let (_width, height) = self.terminal_size;
         execute!(
             stdout(),
@@ -124,6 +85,53 @@ impl Editor {
         for (i, line) in help_lines.iter().enumerate() {
             if i < height as usize {
                 execute!(stdout(), cursor::MoveTo(0, i as u16), style::Print(line))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn main_loop(&mut self) -> Result<()> {
+        use crossterm::event::{self, KeyCode};
+        loop {
+            // 如果正在显示帮助页面
+            if self.show_help_page {
+                self.draw_help_page()?;
+                // 按任意键关闭帮助页面
+                if event::poll(std::time::Duration::from_millis(50))? {
+                    if let event::Event::Key(key_event) = event::read()? {
+                        match key_event.code {
+                            KeyCode::Esc
+                            | KeyCode::Char(_)
+                            | KeyCode::Enter
+                            | KeyCode::Backspace => {
+                                self.show_help_page = false;
+                                self.status_message.clear();
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                continue; // 跳过后续刷新和输入处理
+            }
+
+            self.refresh_screen()?;
+            if self.should_quit {
+                break;
+            }
+            if event::poll(std::time::Duration::from_millis(50))? {
+                if let event::Event::Key(key_event) = event::read()? {
+                    if key_event.kind == event::KeyEventKind::Press {
+                        input::process_key(self, key_event)?;
+                    }
+                }
+            }
+            let new_size = crossterm::terminal::size()?;
+            if new_size != self.terminal_size {
+                self.terminal_size = new_size;
+                // 如果正在显示帮助页且终端大小改变，需要重新绘制
+                if self.show_help_page {
+                    self.help_page_drawn = false;
+                }
             }
         }
         Ok(())

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -99,15 +99,17 @@ impl Editor {
                 // 按任意键关闭帮助页面
                 if event::poll(std::time::Duration::from_millis(50))? {
                     if let event::Event::Key(key_event) = event::read()? {
-                        match key_event.code {
-                            KeyCode::Esc
-                            | KeyCode::Char(_)
-                            | KeyCode::Enter
-                            | KeyCode::Backspace => {
-                                self.show_help_page = false;
-                                self.status_message.clear();
+                        if key_event.kind == event::KeyEventKind::Press {
+                            match key_event.code {
+                                KeyCode::Esc
+                                | KeyCode::Char(_)
+                                | KeyCode::Enter
+                                | KeyCode::Backspace => {
+                                    self.show_help_page = false;
+                                    self.status_message.clear();
+                                }
+                                _ => {}
                             }
-                            _ => {}
                         }
                     }
                 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -95,7 +95,12 @@ impl Editor {
         loop {
             // 如果正在显示帮助页面
             if self.show_help_page {
-                self.draw_help_page()?;
+                // 只在第一次显示或尺寸变化时绘制帮助页面
+                if !self.help_page_drawn {
+                    self.draw_help_page()?;
+                    self.help_page_drawn = true;
+                }
+                
                 // 按任意键关闭帮助页面
                 if event::poll(std::time::Duration::from_millis(50))? {
                     if let event::Event::Key(key_event) = event::read()? {
@@ -106,7 +111,12 @@ impl Editor {
                                 | KeyCode::Enter
                                 | KeyCode::Backspace => {
                                     self.show_help_page = false;
+                                    self.help_page_drawn = false; // 重置绘制状态
                                     self.status_message.clear();
+                                    // 清除屏幕，准备返回编辑器模式
+                                    use crossterm::{execute, terminal};
+                                    use std::io::stdout;
+                                    execute!(stdout(), terminal::Clear(terminal::ClearType::All))?;
                                 }
                                 _ => {}
                             }

--- a/src/editor/input.rs
+++ b/src/editor/input.rs
@@ -52,6 +52,16 @@ pub fn process_key(editor: &mut Editor, key_event: KeyEvent) -> Result<()> {
                 "多光标已关闭".to_string()
             };
         }
+        // Ctrl+G 打开帮助页面
+        KeyEvent {
+            code: KeyCode::Char('g'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        } => {
+            editor.show_help_page = true;
+            editor.status_message = "按任意键返回编辑器".to_string();
+            return Ok(());
+        }
         KeyEvent {
             code: KeyCode::Up,
             modifiers: KeyModifiers::ALT,

--- a/src/editor/input.rs
+++ b/src/editor/input.rs
@@ -59,6 +59,7 @@ pub fn process_key(editor: &mut Editor, key_event: KeyEvent) -> Result<()> {
             ..
         } => {
             editor.show_help_page = true;
+            editor.help_page_drawn = false; // 确保下次会重新绘制帮助页面
             editor.status_message = "按任意键返回编辑器".to_string();
             return Ok(());
         }

--- a/src/editor/status.rs
+++ b/src/editor/status.rs
@@ -1,6 +1,6 @@
 use crate::editor::Editor;
 use crate::Result;
-use crossterm::style::{Color, ResetColor, SetBackgroundColor, SetForegroundColor};
+use crossterm::style::{Color, ResetColor, SetForegroundColor};
 use crossterm::terminal::ClearType;
 use crossterm::{cursor, execute, style, terminal};
 use std::io::stdout;
@@ -95,7 +95,7 @@ pub fn draw_status_bar(editor: &Editor) -> Result<()> {
     // 最下方帮助栏始终不被覆盖
     execute!(stdout(), cursor::MoveTo(0, height - 1))?;
     execute!(stdout(), terminal::Clear(ClearType::CurrentLine))?;
-    let help = "^X 退出  ^O 保存  ^C 多光标  Alt+方向键 移动多光标";
+    let help = "^X 退出  ^O 保存  ^G 帮助  ^C 多光标  Alt+方向键 移动多光标";
     execute!(
         stdout(),
         SetForegroundColor(Color::Black),

--- a/test.txt
+++ b/test.txt
@@ -1,3 +1,1 @@
-
-
-Testing rsnano...
+test content

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,0 +1,1 @@
+test content


### PR DESCRIPTION
按下 Ctrl + G 即可进入，按任意键退出

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an in-app help page accessible via Ctrl+G.
  - Help overlay renders once, adapts to terminal resize, and closes on key press.
  - Status bar now lists the new ^G Help shortcut.

- Chores
  - Added simple demo and test files.
  - Updated sample test content for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->