### PR TITLE
fix: 修复小屏下崩溃的问题

### DIFF
--- a/src/editor/status.rs
+++ b/src/editor/status.rs
@@ -22,7 +22,7 @@ pub fn draw_status_bar(editor: &Editor) -> Result<()> {
             style::SetBackgroundColor(Color::White),
             style::Print(&msg),
         )?;
-        let remaining = width as usize - msg_len;
+        let remaining = (width as usize).saturating_sub(msg_len);
         if remaining > 0 {
             execute!(stdout(), style::Print(" ".repeat(remaining)))?;
         }
@@ -36,7 +36,7 @@ pub fn draw_status_bar(editor: &Editor) -> Result<()> {
             style::SetBackgroundColor(Color::White),
             style::Print(msg),
         )?;
-        let remaining = width as usize - msg_len;
+        let remaining = (width as usize).saturating_sub(msg_len);
         if remaining > 0 {
             execute!(stdout(), style::Print(" ".repeat(remaining)))?;
         }
@@ -72,14 +72,14 @@ pub fn draw_status_bar(editor: &Editor) -> Result<()> {
         if !editor.status_message.is_empty() {
             let left_len = status.len();
             let right_msg = format!("  {}", editor.status_message);
-            let space = width as usize - left_len - right_msg.len();
+            let space = (width as usize).saturating_sub(left_len + right_msg.len());
             if space > 0 {
                 status.push_str(&" ".repeat(space));
             }
             status.push_str(&right_msg);
         } else {
             let status_len = status.len();
-            let remaining = width as usize - status_len;
+            let remaining = (width as usize).saturating_sub(status_len);
             if remaining > 0 {
                 status.push_str(&" ".repeat(remaining));
             }
@@ -102,7 +102,7 @@ pub fn draw_status_bar(editor: &Editor) -> Result<()> {
         style::SetBackgroundColor(Color::White),
         style::Print(help),
     )?;
-    let remaining = width as usize - help.len();
+    let remaining = (width as usize).saturating_sub(help.len());
     if remaining > 0 {
         execute!(stdout(), style::Print(" ".repeat(remaining)))?;
     }


### PR DESCRIPTION
防止窗口宽度过小或字符串过长而导致 panic，例如在 termux 中使用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented status bar rendering glitches when text exceeds available width, ensuring graceful handling of long filenames, messages, and narrow terminals.
  * Resolved misalignment and spacing issues across all status bar states: save prompt, exit confirmation, normal status line, right-side status message, and bottom help line.
  * Improved stability by eliminating edge-case underflow/overflow in spacing calculations, resulting in consistent layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->